### PR TITLE
converting false to a pointer type

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -141,7 +141,7 @@ private slots:
     /// \param[in] filename  Name of the packed APK file.
     /// \param[in] isSuccess \c FALSE if APK is packed with warnings.
     /// \param[in] text      Additional message text.
-    void apkPacked(QString filename, bool isSuccess = true, QString text = false);
+    void apkPacked(QString filename, bool isSuccess = true, QString text = "false");
 
     void apkUnpacked(QString filename);             ///< Handle APK unpacked from the \c filename.
     void resetSettings();                           ///< Reset settings to default.


### PR DESCRIPTION
converting false to a pointer type of QString::QString(const char*)