### PR TITLE
Fixing compiler warnings

### DIFF
--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -64,6 +64,11 @@ void Application::msgHandler(QtMsgType type, const QMessageLogContext &, const Q
         ts << line;
         fprintf(stderr, "%s", qPrintable(line));
         break;
+    case QtInfoMsg:
+        line = QString("[%1]  %2\n").arg(TIME).arg(msg);
+        ts << line;
+        fprintf(stderr, "%s", qPrintable(line));
+        break;
     case QtFatalMsg:
         line = QString("[%1] Fatal: %2\n").arg(TIME, msg);
         ts << line;


### PR DESCRIPTION
enumeration value 'QtInfoMsg' not handled in switch  which causes the compiler to generate a warning :) .